### PR TITLE
商品単価1000円以上の商品をカートに入れた際、千の位の値しか入らないミスを修正。

### DIFF
--- a/html/pages/tpl/shop/details.php
+++ b/html/pages/tpl/shop/details.php
@@ -148,7 +148,7 @@
                               cart_info.remake_image = $('#remake_image').attr('src');
                               cart_info.product_color = $('#remake_color').css('background-color');
                               cart_info.product_color_name = doc.data().color_name;
-                              cart_info.price = $('#price').text().substr(1);
+                              cart_info.price = $('#price').text().substr(1).replace(/,/g, '');
                               cart_info.remake_icon = $('#remake_icon').attr('src');
                               cart_info.category_id = $('#remake_icon').attr('src').charAt(17);
                                //sessionはstring型でないと扱えないため、JSONを使用している


### PR DESCRIPTION
html/pages/tpl/shop/details.phpのカートに入れる動作を行った際、商品単価1000円台のものは1円でカートに入ってしまうという、単価1000円以上になると千の位からしか入らないミスを修正しました。